### PR TITLE
enable frecency pings for all branches so analysis can be performed

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -6,7 +6,7 @@ class Feature {
     this.branchConfigurations = {
       control: {
         modelNumber: null,
-        submitFrecencyUpdate: false,
+        submitFrecencyUpdate: true,
       },
       model1: {
         modelNumber: 1,
@@ -22,7 +22,7 @@ class Feature {
       },
       "model3-not-submitting": {
         modelNumber: 3,
-        submitFrecencyUpdate: false,
+        submitFrecencyUpdate: true,
       },
       "model4-submitting": {
         modelNumber: 4,
@@ -30,7 +30,7 @@ class Feature {
       },
       "model4-not-submitting": {
         modelNumber: 4,
-        submitFrecencyUpdate: false,
+        submitFrecencyUpdate: true,
       },
     };
   }


### PR DESCRIPTION
We need to upload pings for two distinct reasons : 

a) to train a model
b) to do post-experiment analysis


We previously disabled uploads for branches that do no require training.

I've enabled uploads across all branches to fix the ability to do post-experiment analysis.
